### PR TITLE
Changed to Open.MP, Removed unsupported libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you know of a plugin that isn't here, please either add it or open an issue.
 
 You can also simply add the dependency directly to `pawn.json` if you prefer.
 
-* `sampctl package install samp-incognito/samp-streamer-plugin`
+* `sampctl install samp-incognito/samp-streamer-plugin`
 
 ### 2. Add The `#include` Entry to `test.pwn`
 

--- a/pawn.json
+++ b/pawn.json
@@ -2,19 +2,22 @@
 	"user": "sampctl",
 	"repo": "plugin-build-tests",
 	"entry": "test.pwn",
-	"output": "test.amx",
+	"output": "gamemodes/test.amx",
 	"dependencies": [
-		"sampctl/samp-stdlib",
+		"openmultiplayer/omp-stdlib",
+		"pawn-lang/samp-stdlib@open.mp",
+		"pawn-lang/pawn-stdlib@open.mp",
 		"AmyrAhmady/samp-plugin-crashdetect",
 		"BigETI/pawn-memory",
-		"maddinat0r/sscanf",
+		"Y-Less/sscanf",
 		"samp-incognito/samp-streamer-plugin",
-		"IllidanS4/YSF",
-		"IllidanS4/PawnPlus",
+		"IS4Code/PawnPlus",
 		"Southclaws/pawn-uuid",
 		"Southclaws/pawn-fsutil",
-		"ziggi/rustext",
-		"Southclaws/samp-plugin-mapandreas",
-		"Southclaws/pawn-redis"
-	]
+		"Southclaws/pawn-redis",
+		"component://katursis/Pawn.CMD"
+	],
+	"runtime": {
+		"version": "openmp"
+	}
 }

--- a/test.pwn
+++ b/test.pwn
@@ -1,26 +1,25 @@
-#include <a_samp>
+#include <open.mp>
 
 
 // -
 // Dependency includes
 // -
 
-#include <crashdetect> // Zeex/samp-plugin-crashdetect
-#include <memory> // BigETI/pawn-memory
-#include <sscanf2> // maddinat0r/sscanf
-#include <streamer> // samp-incognito/samp-streamer-plugin
-#include <YSF> // IllidanS4/YSF
-#include <PawnPlus> // IllidanS4/PawnPlus
-#include <uuid> // Southclaws/pawn-uuid
-#include <fsutil> // Southclaws/pawn-fsutil
-#include <rustext> // ziggi/rustext
-#include <mapandreas> // Southclaws/samp-plugin-mapandreas
-#include <redis> // Southclaws/pawn-redis
+#include <crashdetect>  // AmyrAhmady/samp-plugin-crashdetect:v4.22
+#include <memory>       // BigETI/pawn-memory
+#include <sscanf2>      // Y-Less/sscanf
+#include <streamer>     // samp-incognito/samp-streamer-plugin
+#include <PawnPlus>     // IS4Code/PawnPlus
+#include <uuid>         // Southclaws/pawn-uuid
+#include <fsutil>       // Southclaws/pawn-fsutil
+#include <redis>        // Southclaws/pawn-redis
 
+#define __cplusplus     // internal directive for Pawn.CMD in component mode
+#include <Pawn.CMD>     // katursis/Pawn.CMD/releases
 // -
 // include `main()` for running
 // -
 
 main() {
-    //
+    print("Hello, this is sampctl!");
 }


### PR DESCRIPTION
Obsolete libraries, including those currently unsupported, such as YSF, rustext, and samp-plugin-mapandreas, have been replaced. The Open.MP starter kit has been installed.