### PR TITLE
Fix adding wrong definition

### DIFF
--- a/test.pwn
+++ b/test.pwn
@@ -1,11 +1,10 @@
 #include <open.mp>
 
-
 // -
 // Dependency includes
 // -
 
-#include <crashdetect>  // AmyrAhmady/samp-plugin-crashdetect:v4.22
+#include <crashdetect>  // AmyrAhmady/samp-plugin-crashdetect
 #include <memory>       // BigETI/pawn-memory
 #include <sscanf2>      // Y-Less/sscanf
 #include <streamer>     // samp-incognito/samp-streamer-plugin
@@ -13,9 +12,8 @@
 #include <uuid>         // Southclaws/pawn-uuid
 #include <fsutil>       // Southclaws/pawn-fsutil
 #include <redis>        // Southclaws/pawn-redis
+#include <Pawn.CMD>     // katursis/Pawn.CMD
 
-#define __cplusplus     // internal directive for Pawn.CMD in component mode
-#include <Pawn.CMD>     // katursis/Pawn.CMD/releases
 // -
 // include `main()` for running
 // -


### PR DESCRIPTION
Based on this: https://github.com/sampctl/plugin-build-tests/commit/051f5817c944b883f9a13902b84b085364046f01#r188293369

the PR removes the definition which is not applicable for Pawn environment